### PR TITLE
optional static ip

### DIFF
--- a/4-optional-static-ip/backend.tf
+++ b/4-optional-static-ip/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "project-koko-370310-tf-state"
+    prefix = "practice/4-optional-static-ip"
+  }
+}

--- a/4-optional-static-ip/main.tf
+++ b/4-optional-static-ip/main.tf
@@ -17,9 +17,20 @@ resource "google_compute_instance" "this" {
 
   network_interface {
     network = "default"
-    access_config {
-      nat_ip = var.static_ip ? google_compute_address.static[0].address : null
+    # access_config {
+    #   nat_ip = var.static_ip ? google_compute_address.static[0].address : null
+    # }
+
+
+    # There is other way to do it using dynamic
+    # when there is no google_compute_addres.static created this code below will evaluate as null
+    dynamic "access_config" {
+      for_each = google_compute_address.static
+      content {
+        nat_ip = google_compute_address.static[0].address
+      }
     }
+
   }
 }
 

--- a/4-optional-static-ip/main.tf
+++ b/4-optional-static-ip/main.tf
@@ -1,0 +1,25 @@
+resource "google_compute_address" "static" {
+  count = var.static_ip ? 1 : 0
+  name  = "ipv4-address"
+}
+
+resource "google_compute_instance" "this" {
+  provider     = google
+  zone         = var.zone
+  name         = var.server_name
+  machine_type = var.machine_type
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      nat_ip = var.static_ip ? google_compute_address.static[0].address : null
+    }
+  }
+}
+

--- a/4-optional-static-ip/provider.tf
+++ b/4-optional-static-ip/provider.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.6.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.29.0"
+    }
+  }
+}
+
+# GCP Provider
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}

--- a/4-optional-static-ip/terraform.tfvars
+++ b/4-optional-static-ip/terraform.tfvars
@@ -1,0 +1,3 @@
+project_id  = "project-koko-370310"
+server_name = "optional-static-ip"
+static_ip   = true

--- a/4-optional-static-ip/variables.tf
+++ b/4-optional-static-ip/variables.tf
@@ -1,0 +1,35 @@
+variable "project_id" {
+  type        = string
+  description = "google cloud project id"
+}
+
+variable "region" {
+  type        = string
+  default     = "us-central1"
+  description = "google cloud default region"
+}
+
+
+variable "zone" {
+  type        = string
+  default     = "us-central1-a"
+  description = "google cloud default zone"
+}
+
+variable "server_name" {
+  type        = string
+  description = "Name of webserver"
+}
+
+
+variable "machine_type" {
+  type        = string
+  description = "Machine Type"
+  default     = "e2-micro"
+}
+
+
+variable "static_ip" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
Using conditional expression to assign static IP address dynamically.

![image](https://github.com/labasubagia/terraform-practice/assets/31754766/5294dae8-49e9-484d-b119-596e7b46d2b5)

![image](https://github.com/labasubagia/terraform-practice/assets/31754766/16391c98-70f8-41e0-a021-da8d5d225cf8)

Or using dynamic blocks, when there is no google_compute_address.static created, it will evaluated as null.
![image](https://github.com/labasubagia/terraform-practice/assets/31754766/e2710a6b-cf1a-4d27-8225-4986bd099566)
