### PR TITLE
Example of using terraform data source

### DIFF
--- a/6-data-source/backend.tf
+++ b/6-data-source/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "project-koko-370310-tf-state"
+    prefix = "practice/6-data-source"
+  }
+}

--- a/6-data-source/main.tf
+++ b/6-data-source/main.tf
@@ -1,0 +1,57 @@
+# PART 1
+
+# using data to access information of resource that provisioned outside this terraform
+# use previous resource chapter as example
+
+data "google_compute_instance" "this" {
+  # use from 5-openvpn as example
+  name = "vm-openvpn"
+}
+output "ip-address" {
+  value = format("IP Address of existing server: %s", data.google_compute_instance.this.network_interface[0].access_config[0].nat_ip)
+}
+
+
+# PART 2
+# create compute instance in all zone 
+data "google_compute_zones" "available" {
+}
+resource "google_compute_instance" "all_zone" {
+  count        = length(data.google_compute_zones.available.names)
+  name         = "server_all_zone"
+  machine_type = "e2-micro"
+  zone         = data.google_compute_zones.available.names[count.index % length(data.google_compute_zones.available.names)]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+  network_interface {
+    network = "default"
+    access_config {
+    }
+  }
+}
+
+# using splat operator splat expression
+output "zones-splat" {
+  description = "list of zones using splat expression"
+  value       = google_compute_instance.all_zone[*].zone
+}
+
+# using splat operator for expression
+output "zones-for" {
+  description = "List of zones using a for loop"
+  value       = [for server in google_compute_instance.all_zone : server.zone]
+}
+
+output "zones-by-servers" {
+  description = "Name of zone for each server"
+  value       = [for s in google_compute_instance.all_zone[*] : "${s.name}: ${s.zone}"]
+}
+
+output "URL_0" {
+  description = "URL of first server"
+  value       = format("http://%s", google_compute_instance.all_zone[0].network_interface[0].access_config[0].nat_ip)
+}

--- a/6-data-source/provider.tf
+++ b/6-data-source/provider.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.6.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.29.0"
+    }
+  }
+}
+
+# GCP Provider
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}

--- a/6-data-source/terraform.tfvars
+++ b/6-data-source/terraform.tfvars
@@ -1,0 +1,1 @@
+project_id = "project-koko-370310"

--- a/6-data-source/variables.tf
+++ b/6-data-source/variables.tf
@@ -1,0 +1,17 @@
+variable "project_id" {
+  type        = string
+  description = "google cloud project id"
+}
+
+variable "region" {
+  type        = string
+  default     = "asia-southeast1"
+  description = "google cloud default region"
+}
+
+
+variable "zone" {
+  type        = string
+  default     = "asia-southeast1-a"
+  description = "google cloud default zone"
+}


### PR DESCRIPTION
Example of using terraform data source with syntax `data`
https://developer.hashicorp.com/terraform/language/data-sources

The first example uses the previous chapter instance, which is still alive, `5-openvpn`.