### PR TITLE
Manage environment (dev, prod, staging, etc)

### DIFF
--- a/8-env/README.md
+++ b/8-env/README.md
@@ -1,0 +1,20 @@
+# Manage Environment
+
+In real-world app development, separate environments are needed for production, dev, staging, etc.
+https://12factor.net/dev-prod-parity
+
+In terraform, several ways exist to make those environments as similar as possible.
+
+## workspaces 
+
+https://developer.hashicorp.com/terraform/cli/workspaces 
+
+The advantage of this approach is that all the environments are similar and reduce code duplication. Still, the disadvantage is that customizing resources for different environments (e.g., dev & prod) becomes challenging.
+
+## directory structure
+
+This approach's advantage is that it is easy to customize different environments separately. For example, the dev environment uses one replica of the VM, but the prod environment uses a minimum of three. The disadvantage is that there is more duplication compared to the previous approach. 
+
+## remote state
+
+There is a use case in which one resource depends on another and has a different lifecycle. for example a connected database instance and a VM. A database is relatively stable and should be running all the time, but VM will be re-created many times (including scale-up / scale-out). There are also case when DB has a separate team and VM is only used by developers. Remote state can also used in **workspaces** or **directory structure**.

--- a/8-env/directory-structure/dev/backend.tf
+++ b/8-env/directory-structure/dev/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "project-koko-370310-tf-state"
+    prefix = "practice/8-env-directory-structure-dev"
+  }
+}

--- a/8-env/directory-structure/dev/main.tf
+++ b/8-env/directory-structure/dev/main.tf
@@ -1,0 +1,13 @@
+module "server1" {
+  source       = "../modules/server"
+  name         = "${var.server_name}-1"
+  machine_size = "small"
+  environment  = var.environment
+}
+
+module "server2" {
+  source       = "../modules/server"
+  name         = "${var.server_name}-2"
+  machine_size = "small"
+  environment  = var.environment
+}

--- a/8-env/directory-structure/dev/provider.tf
+++ b/8-env/directory-structure/dev/provider.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.6.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.29.0"
+    }
+  }
+}
+
+# GCP Provider
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}

--- a/8-env/directory-structure/dev/terraform.tfvars
+++ b/8-env/directory-structure/dev/terraform.tfvars
@@ -1,0 +1,3 @@
+project_id  = "project-koko-370310"
+server_name = "server-env"
+environment = "dev"

--- a/8-env/directory-structure/dev/variables.tf
+++ b/8-env/directory-structure/dev/variables.tf
@@ -1,0 +1,27 @@
+variable "project_id" {
+  type        = string
+  description = "google cloud project id"
+}
+
+variable "region" {
+  type        = string
+  description = "default region"
+  default     = "asia-southeast1"
+}
+
+variable "zone" {
+  type        = string
+  description = "default zone"
+  default     = "asia-southeast1-a"
+}
+
+variable "server_name" {
+  type        = string
+  description = "name of server"
+}
+
+variable "environment" {
+  type        = string
+  description = "type of environment"
+  default     = "dev"
+}

--- a/8-env/directory-structure/modules/server/main.tf
+++ b/8-env/directory-structure/modules/server/main.tf
@@ -1,0 +1,42 @@
+locals {
+  machine_type_mapping = {
+    small  = "e2-micro"
+    medium = "e2-small"
+    large  = "e2-medium"
+  }
+  machine_type = local.machine_type_mapping[var.machine_size]
+}
+
+resource "google_compute_address" "static" {
+  count = var.static_ip ? 1 : 0
+  name  = "${var.name}-ipv4-address"
+}
+
+resource "google_compute_instance" "this" {
+  name         = var.name
+  zone         = var.zone
+  machine_type = local.machine_type
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    dynamic "access_config" {
+      for_each = google_compute_address.static
+      content {
+        nat_ip = access_config.value["address"]
+      }
+    }
+  }
+
+  metadata_startup_script = file("${path.module}/startup.sh")
+  tags                    = ["http-server"]
+  labels = {
+    "created_by"  = "terraform"
+    "environment" = var.environment
+  }
+}

--- a/8-env/directory-structure/modules/server/outputs.tf
+++ b/8-env/directory-structure/modules/server/outputs.tf
@@ -1,0 +1,11 @@
+output "public_ip_address" {
+  value = var.static_ip ? google_compute_instance.this.network_interface.0.access_config.0.nat_ip : null
+}
+
+output "private_ip_address" {
+  value = google_compute_instance.this.network_interface.0.network_ip
+}
+
+output "self_link" {
+  value = google_compute_instance.this.self_link
+}

--- a/8-env/directory-structure/modules/server/startup.sh
+++ b/8-env/directory-structure/modules/server/startup.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+apt update
+apt -y install apache2
+cat <<EOF > /var/www/html/index.html
+<html><body><p>Hello World!</p></body></html>

--- a/8-env/directory-structure/modules/server/variables.tf
+++ b/8-env/directory-structure/modules/server/variables.tf
@@ -1,0 +1,28 @@
+variable "name" {
+  type = string
+}
+
+variable "machine_size" {
+  type    = string
+  default = "small"
+  validation {
+    condition     = contains(["small", "medium", "large"], var.machine_size)
+    error_message = "The machine size must be one of small, medium and large"
+  }
+}
+
+variable "zone" {
+  type    = string
+  default = "asia-southeast1-a"
+}
+
+variable "static_ip" {
+  type    = bool
+  default = true
+}
+
+variable "environment" {
+  type        = string
+  description = "type of environment"
+  default     = "dev"
+}

--- a/8-env/directory-structure/prod/backend.tf
+++ b/8-env/directory-structure/prod/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "project-koko-370310-tf-state"
+    prefix = "practice/8-env-directory-structure-prod"
+  }
+}

--- a/8-env/directory-structure/prod/main.tf
+++ b/8-env/directory-structure/prod/main.tf
@@ -1,0 +1,20 @@
+module "server1" {
+  source       = "../modules/server"
+  name         = "${var.server_name}-1"
+  machine_size = "medium"
+  environment  = var.environment
+}
+
+module "server2" {
+  source       = "../modules/server"
+  name         = "${var.server_name}-2"
+  machine_size = "medium"
+  environment  = var.environment
+}
+
+module "server3" {
+  source       = "../modules/server"
+  name         = "${var.server_name}-3"
+  machine_size = "large"
+  environment  = var.environment
+}

--- a/8-env/directory-structure/prod/provider.tf
+++ b/8-env/directory-structure/prod/provider.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.6.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.29.0"
+    }
+  }
+}
+
+# GCP Provider
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}

--- a/8-env/directory-structure/prod/terraform.tfvars
+++ b/8-env/directory-structure/prod/terraform.tfvars
@@ -1,0 +1,3 @@
+project_id  = "sampahku-0001"
+server_name = "server-env"
+environment = "prod"

--- a/8-env/directory-structure/prod/variables.tf
+++ b/8-env/directory-structure/prod/variables.tf
@@ -1,0 +1,27 @@
+variable "project_id" {
+  type        = string
+  description = "google cloud project id"
+}
+
+variable "region" {
+  type        = string
+  description = "default region"
+  default     = "asia-southeast1"
+}
+
+variable "zone" {
+  type        = string
+  description = "default zone"
+  default     = "asia-southeast1-a"
+}
+
+variable "server_name" {
+  type        = string
+  description = "name of server"
+}
+
+variable "environment" {
+  type        = string
+  description = "type of environment"
+  default     = "prod"
+}

--- a/8-env/remote-state/cloud-sql/backend.tf
+++ b/8-env/remote-state/cloud-sql/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "project-koko-370310-tf-state"
+    prefix = "practice/8-env/remote-state/cloud-sql"
+  }
+}

--- a/8-env/remote-state/cloud-sql/main.tf
+++ b/8-env/remote-state/cloud-sql/main.tf
@@ -1,0 +1,14 @@
+resource "random_string" "this" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+resource "google_sql_database_instance" "main" {
+  name             = "main-instance-${random_string.this.result}"
+  database_version = "POSTGRES_11"
+  region           = var.region
+  settings {
+    tier = "db-f1-micro"
+  }
+}

--- a/8-env/remote-state/cloud-sql/outputs.tf
+++ b/8-env/remote-state/cloud-sql/outputs.tf
@@ -1,0 +1,3 @@
+output "connection_name" {
+  value = google_sql_database_instance.main.connection_name
+}

--- a/8-env/remote-state/cloud-sql/provider.tf
+++ b/8-env/remote-state/cloud-sql/provider.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.6.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.29.0"
+    }
+  }
+}
+
+# GCP Provider
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}

--- a/8-env/remote-state/cloud-sql/terraform.tfvars
+++ b/8-env/remote-state/cloud-sql/terraform.tfvars
@@ -1,0 +1,2 @@
+project_id  = "project-koko-370310"
+server_name = "server-env"

--- a/8-env/remote-state/cloud-sql/variables.tf
+++ b/8-env/remote-state/cloud-sql/variables.tf
@@ -1,0 +1,21 @@
+variable "project_id" {
+  type        = string
+  description = "google cloud project id"
+}
+
+variable "region" {
+  type        = string
+  description = "default region"
+  default     = "asia-southeast1"
+}
+
+variable "zone" {
+  type        = string
+  description = "default zone"
+  default     = "asia-southeast1-a"
+}
+
+variable "server_name" {
+  type        = string
+  description = "name of server"
+}

--- a/8-env/remote-state/compute-instance/backend.tf
+++ b/8-env/remote-state/compute-instance/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "project-koko-370310-tf-state"
+    prefix = "practice/8-env/remote-state/compute-instance"
+  }
+}

--- a/8-env/remote-state/compute-instance/data.tf
+++ b/8-env/remote-state/compute-instance/data.tf
@@ -1,0 +1,13 @@
+# remote state from cloud sql
+data "terraform_remote_state" "cloud_sql" {
+  backend = "gcs"
+  config = {
+    bucket = "project-koko-370310-tf-state"
+    prefix = "practice/8-env/remote-state/cloud-sql"
+  }
+}
+
+# just for log
+output "connection_name" {
+  value = data.terraform_remote_state.cloud_sql.outputs.connection_name
+}

--- a/8-env/remote-state/compute-instance/main.tf
+++ b/8-env/remote-state/compute-instance/main.tf
@@ -1,0 +1,25 @@
+resource "google_compute_instance" "this" {
+  name         = var.server_name
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      // Ephemeral public IP
+    }
+  }
+
+  metadata_startup_script = templatefile("startup.tftpl", { connection_name = data.terraform_remote_state.cloud_sql.outputs.connection_name })
+  tags                    = ["http-server"]
+}
+
+output "URL" {
+  value = format("http://%s", google_compute_instance.this.network_interface[0].access_config[0].nat_ip)
+}

--- a/8-env/remote-state/compute-instance/provider.tf
+++ b/8-env/remote-state/compute-instance/provider.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.6.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.29.0"
+    }
+  }
+}
+
+# GCP Provider
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}

--- a/8-env/remote-state/compute-instance/startup.tftpl
+++ b/8-env/remote-state/compute-instance/startup.tftpl
@@ -1,0 +1,7 @@
+#! /bin/bash
+apt update
+apt -y install apache2
+cat <<EOF > /var/www/html/index.html
+<html><body><p>Hello World!</p>
+<p>The CloudSQL connection name is: ${connection_name}</body></
+html>

--- a/8-env/remote-state/compute-instance/terraform.tfvars
+++ b/8-env/remote-state/compute-instance/terraform.tfvars
@@ -1,0 +1,2 @@
+project_id  = "project-koko-370310"
+server_name = "remote-state"

--- a/8-env/remote-state/compute-instance/variables.tf
+++ b/8-env/remote-state/compute-instance/variables.tf
@@ -1,0 +1,27 @@
+variable "project_id" {
+  type        = string
+  description = "google cloud project id"
+}
+
+variable "region" {
+  type        = string
+  description = "default region"
+  default     = "asia-southeast1"
+}
+
+variable "zone" {
+  type        = string
+  description = "default zone"
+  default     = "asia-southeast1-a"
+}
+
+variable "server_name" {
+  type        = string
+  description = "name of server"
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Machine Type"
+  default     = "e2-micro"
+}

--- a/8-env/workspaces/backend.tf
+++ b/8-env/workspaces/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "project-koko-370310-tf-state"
+    prefix = "practice/8-env-workspace"
+  }
+}

--- a/8-env/workspaces/main.tf
+++ b/8-env/workspaces/main.tf
@@ -1,0 +1,22 @@
+module "server1" {
+  source      = "./modules/server"
+  name        = "${var.server_name}-1"
+  environment = var.environment
+}
+
+module "server2" {
+  source       = "./modules/server"
+  name         = "${var.server_name}-2"
+  zone         = var.zone
+  machine_size = "medium"
+  environment  = var.environment
+}
+
+module "server3" {
+  source       = "./modules/server"
+  name         = "${var.server_name}-3"
+  zone         = "asia-southeast1-b"
+  machine_size = "large"
+  static_ip    = true
+  environment  = var.environment
+}

--- a/8-env/workspaces/modules/server/main.tf
+++ b/8-env/workspaces/modules/server/main.tf
@@ -1,0 +1,42 @@
+locals {
+  machine_type_mapping = {
+    small  = "e2-micro"
+    medium = "e2-small"
+    large  = "e2-medium"
+  }
+  machine_type = local.machine_type_mapping[var.machine_size]
+}
+
+resource "google_compute_address" "static" {
+  count = var.static_ip ? 1 : 0
+  name  = "${var.name}-ipv4-address"
+}
+
+resource "google_compute_instance" "this" {
+  name         = var.name
+  zone         = var.zone
+  machine_type = local.machine_type
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    dynamic "access_config" {
+      for_each = google_compute_address.static
+      content {
+        nat_ip = access_config.value["address"]
+      }
+    }
+  }
+
+  metadata_startup_script = file("${path.module}/startup.sh")
+  tags                    = ["http-server"]
+  labels = {
+    "created_by"  = "terraform"
+    "environment" = var.environment
+  }
+}

--- a/8-env/workspaces/modules/server/outputs.tf
+++ b/8-env/workspaces/modules/server/outputs.tf
@@ -1,0 +1,11 @@
+output "public_ip_address" {
+  value = var.static_ip ? google_compute_instance.this.network_interface.0.access_config.0.nat_ip : null
+}
+
+output "private_ip_address" {
+  value = google_compute_instance.this.network_interface.0.network_ip
+}
+
+output "self_link" {
+  value = google_compute_instance.this.self_link
+}

--- a/8-env/workspaces/modules/server/startup.sh
+++ b/8-env/workspaces/modules/server/startup.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+apt update
+apt -y install apache2
+cat <<EOF > /var/www/html/index.html
+<html><body><p>Hello World!</p></body></html>

--- a/8-env/workspaces/modules/server/variables.tf
+++ b/8-env/workspaces/modules/server/variables.tf
@@ -1,0 +1,28 @@
+variable "name" {
+  type = string
+}
+
+variable "machine_size" {
+  type    = string
+  default = "small"
+  validation {
+    condition     = contains(["small", "medium", "large"], var.machine_size)
+    error_message = "The machine size must be one of small, medium and large"
+  }
+}
+
+variable "zone" {
+  type    = string
+  default = "asia-southeast1-a"
+}
+
+variable "static_ip" {
+  type    = bool
+  default = true
+}
+
+variable "environment" {
+  type        = string
+  description = "type of environment"
+  default     = "dev"
+}

--- a/8-env/workspaces/prod.tfvars
+++ b/8-env/workspaces/prod.tfvars
@@ -1,0 +1,10 @@
+# TO RUN THIS
+# $ terraform workspace new prod
+# $ terraform workspace list
+# $ terraform workspace select prod
+# $ terraform apply -var-file prod.tfvars
+# https://developer.hashicorp.com/terraform/language/state/workspaces
+
+project_id  = "sampahku-0001"
+server_name = "server-env"
+environment = "prod"

--- a/8-env/workspaces/provider.tf
+++ b/8-env/workspaces/provider.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.6.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.29.0"
+    }
+  }
+}
+
+# GCP Provider
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}

--- a/8-env/workspaces/terraform.tfvars
+++ b/8-env/workspaces/terraform.tfvars
@@ -1,0 +1,3 @@
+project_id  = "project-koko-370310"
+server_name = "server-env"
+environment = "dev"

--- a/8-env/workspaces/variables.tf
+++ b/8-env/workspaces/variables.tf
@@ -1,0 +1,27 @@
+variable "project_id" {
+  type        = string
+  description = "google cloud project id"
+}
+
+variable "region" {
+  type        = string
+  description = "default region"
+  default     = "asia-southeast1"
+}
+
+variable "zone" {
+  type        = string
+  description = "default zone"
+  default     = "asia-southeast1-a"
+}
+
+variable "server_name" {
+  type        = string
+  description = "name of server"
+}
+
+variable "environment" {
+  type        = string
+  description = "type of environment"
+  default     = "dev"
+}


### PR DESCRIPTION
In real-world app development, separate environments are needed for production, dev, staging, etc.
https://12factor.net/dev-prod-parity

In terraform, several ways exist to make those environments as similar as possible.

1. workspaces https://developer.hashicorp.com/terraform/cli/workspaces 
The advantage of this approach is that all the environments are similar and reduce code duplication. Still, the disadvantage is that customizing resources for different environments (e.g., dev & prod) becomes challenging.

1. directory structure
This approach's advantage is that it is easy to customize different environments separately. For example, the dev environment uses one replica of the VM, but the prod environment uses a minimum of three. The disadvantage is that there is more duplication compared to the previous approach. 

1. remote state
There is a use case in which one resource depends on another and has a different lifecycle. for example a connected database instance and a VM. A database is relatively stable and should be running all the time, but VM will be re-created many times (including scale-up / scale-out). There are also case when DB has a separate team and VM is only used by developers. Remote state can also used in **workspaces** or **directory structure**.